### PR TITLE
Refactor driver assistant agent with planner-driven ReAct loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,49 @@
-# hello-world
+# Driver Assistant Agent
 
-first one
-I am learning how to use github, the prononsiation is g not j, only I myself can understand what I am saying.
+基于 FastAPI 与 LangGraph 的司机助理 Agent 示例，使用 uv 进行依赖管理（兼容 `uv pip install -r requirements` 形式）。该服务模拟对接业务系统，构建具备 **Planner + Memory + ReAct** 能力的智能体，覆盖司机画像、货源画像、触发机制和行业知识库查询等核心能力。
 
-## Playful greetings
+## 快速开始
 
-現在你可以使用 `greetings.py` 腳本來製作更多好玩的問候樣式：
+1. 安装依赖（推荐使用 [uv](https://github.com/astral-sh/uv)）：
+   ```bash
+   uv pip install -r <(uv pip compile pyproject.toml)
+   ```
+   或者使用标准 pip：
+   ```bash
+   pip install -e .
+   ```
 
-- 🎉 **Emoji 派對**：一鍵噴發的彩帶與歡樂能量。
-- ✨ **霓虹燈招牌**：專屬於你的像素霓虹歡迎牌。
-- 🌏 **多國語言浪潮**：一次收集多種語言的問候。
-- 💌 **ASCII 明信片**：把祝福寫進小小的字符圖像。
-- 🎮 **Chiptune 開場**：8-bit 電子音帶你進入遊戲開局。
+2. 启动服务：
+   ```bash
+   uvicorn agent_app.main:app --reload
+   ```
 
-### 如何使用
+3. 触发 Agent：
+   ```bash
+   curl -X POST http://localhost:8000/agent/v1/trigger \
+     -H "Content-Type: application/json" \
+     -d '{
+       "driver_id": "DRV-001",
+       "channel": "app",
+       "utterance": "帮我找找高价货",
+       "timestamp": "2024-04-17T12:00:00Z"
+     }'
+   ```
 
-```bash
-python greetings.py            # 隨機問候
-python greetings.py 小明       # 指定名字
-python greetings.py --style neon 小美
-python greetings.py --random 小王
-```
+响应中会包含司机画像（含最近 10 条履约/取消/未成交记录和语音摘要）、偏好标签、推荐的货源列表，以及可追溯的 Planner 步骤。
 
-每次執行都能帶來不一樣的驚喜問候，快和朋友分享吧！
+## 目录结构
+
+- `agent_app/models.py`：领域模型与 Planner 步骤定义。
+- `agent_app/memory.py`：对话记忆环形缓存，负责多轮上下文保留。
+- `agent_app/planner.py`：基于业务意图的规则化 Planner，生成工具执行计划。
+- `agent_app/agent.py`：LangGraph 编排的智能体，结合 Planner、记忆与 ReAct 工序。
+- `agent_app/tools.py`：Mock 工具层，覆盖司机画像、货源画像、触发识别、行业知识库等能力。
+- `agent_app/main.py`：FastAPI 服务入口。
+- `pyproject.toml`：项目依赖与 uv 兼容配置。
+
+## 后续规划
+
+- 接入真实业务系统接口替换 Mock 工具。
+- 增加对话记忆压缩与多轮协作的子 Agent。
+- 构建自动化评测集与离线指标监控。

--- a/agent_app/__init__.py
+++ b/agent_app/__init__.py
@@ -1,0 +1,6 @@
+"""Driver assistant agent package."""
+
+from .agent import DriverAssistantAgent
+from .main import create_app
+
+__all__ = ["create_app", "DriverAssistantAgent"]

--- a/agent_app/agent.py
+++ b/agent_app/agent.py
@@ -1,0 +1,225 @@
+"""Driver assistant agent orchestrated via LangGraph."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List, Literal, Optional, TypedDict
+
+from langgraph.graph import END, StateGraph
+
+from .config import AgentConfig, get_agent_config
+from .memory import ConversationMemory
+from .models import (
+    AgentResponse,
+    DriverProfile,
+    FreightOpportunity,
+    IntentType,
+    PlanStep,
+    PlanStepType,
+    TriggerContext,
+)
+from .planner import RuleBasedPlanner
+from .tools import DriverAssistantToolkit
+
+
+class AgentState(TypedDict, total=False):
+    """Mutable state passed between planner, executor, and reactor nodes."""
+
+    trigger: TriggerContext
+    memory: ConversationMemory
+    intent: IntentType
+    plan: List[PlanStep]
+    step_index: int
+    observations: List[str]
+    profile: DriverProfile
+    recommendations: List[FreightOpportunity]
+    knowledge: str
+    last_observation: str
+    response: AgentResponse
+
+
+class DriverAssistantAgent:
+    """High-level agent encapsulating planner, memory, and tool execution."""
+
+    def __init__(
+        self,
+        *,
+        toolkit: Optional[DriverAssistantToolkit] = None,
+        config: Optional[AgentConfig] = None,
+        planner: Optional[RuleBasedPlanner] = None,
+    ) -> None:
+        self.toolkit = toolkit or DriverAssistantToolkit()
+        self.config = config or get_agent_config()
+        self.planner = planner or RuleBasedPlanner()
+        self._graph = self._build_graph().compile()
+        self._memory_store: Dict[str, ConversationMemory] = {}
+
+    def _build_graph(self) -> StateGraph:
+        graph = StateGraph(AgentState)
+
+        def plan_node(state: AgentState) -> AgentState:
+            trigger = state["trigger"]
+            memory = state.get("memory") or ConversationMemory(self.config.max_history_turns)
+            memory.add_turn("user", trigger.utterance, timestamp=trigger.timestamp)
+            intent = self.toolkit.intent_router.infer_intent(trigger.utterance)
+            plan = self.planner.make_plan(intent, trigger, memory)
+            state.update(
+                {
+                    "memory": memory,
+                    "intent": intent,
+                    "plan": plan,
+                    "step_index": 0,
+                    "observations": [],
+                }
+            )
+            return state
+
+        def act_node(state: AgentState) -> AgentState:
+            plan = state["plan"]
+            idx = state["step_index"]
+            step = plan[idx]
+            trigger = state["trigger"]
+
+            observation: str
+            if step.step_type == PlanStepType.REASON:
+                if step.name == "align_preferences":
+                    profile = state.get("profile")
+                    if not profile:
+                        profile = self.toolkit.driver_profile.fetch_profile(trigger.driver_id)
+                        state["profile"] = profile
+                    pref = profile.preferences
+                    observation = (
+                        "偏好侧重：高价({}), 近距离({}), 装货及时({})。"
+                    ).format(
+                        "是" if pref.prefers_high_price else "否",
+                        "是" if pref.prefers_nearby else "否",
+                        "是" if pref.prefers_fast_turnaround else "否",
+                    )
+                elif step.name == "profile_summary":
+                    profile = state.get("profile")
+                    if profile:
+                        observation = (
+                            f"画像得分 {profile.score:.2f}，最近履约 {len(profile.recent_wins)}，取消 {len(profile.recent_cancellations)}，未成交 {len(profile.recent_missed)}。"
+                        )
+                    else:
+                        observation = "暂未获取画像，建议先刷新画像信息。"
+                elif step.name == "clarify_question":
+                    observation = f"司机问题指向：{trigger.utterance}，准备检索对应规则。"
+                elif step.name == "ground_answer":
+                    knowledge = state.get("knowledge")
+                    observation = (
+                        f"结合司机历史与知识库回答，给出可执行建议：{knowledge}" if knowledge else "等待知识库结果以给出建议。"
+                    )
+                elif step.name == "clarify_intent":
+                    observation = "无法定位意图，需要向司机澄清需求。"
+                else:
+                    observation = step.description
+            elif step.name == "fetch_profile":
+                profile = self.toolkit.driver_profile.fetch_profile(trigger.driver_id)
+                state["profile"] = profile
+                observation = "司机画像已刷新，包含最新履约记录和偏好。"
+            elif step.name == "recommend_freight":
+                profile = state.get("profile") or self.toolkit.driver_profile.fetch_profile(trigger.driver_id)
+                recommendations = self.toolkit.freight_catalog.recommend(profile)
+                state["recommendations"] = recommendations
+                observation = f"根据画像匹配到 {len(recommendations)} 条候选货源。"
+            elif step.name == "query_knowledge":
+                knowledge = self.toolkit.knowledge_base.query(trigger.utterance)
+                state["knowledge"] = knowledge
+                observation = f"知识库反馈：{knowledge}"
+            else:
+                observation = f"暂不支持的执行步骤：{step.name}"
+
+            state["last_observation"] = observation
+            return state
+
+        def react_node(state: AgentState) -> AgentState:
+            observation = state.get("last_observation", "")
+            observations = state.get("observations", [])
+            step = state["plan"][state["step_index"]]
+            observations.append(f"[{step.name}] {observation}")
+            state["observations"] = observations
+            state["step_index"] = state.get("step_index", 0) + 1
+            return state
+
+        def should_continue(state: AgentState) -> Literal["continue", "respond"]:
+            if state.get("step_index", 0) < len(state.get("plan", [])):
+                return "continue"
+            return "respond"
+
+        def respond_node(state: AgentState) -> AgentState:
+            intent = state.get("intent", IntentType.UNKNOWN)
+            profile = state.get("profile")
+            recommendations = state.get("recommendations", [])
+            knowledge = state.get("knowledge")
+            memory = state.get("memory") or ConversationMemory(self.config.max_history_turns)
+
+            if intent == IntentType.FIND_FREIGHT and recommendations:
+                rec_lines = [
+                    f"{rec.order_id}: {rec.origin}->{rec.destination}, ¥{rec.price:.0f}, {rec.distance_km:.0f}公里, 装货 {rec.pickup_time:%m-%d %H:%M}"
+                    for rec in recommendations
+                ]
+                message = "\n".join(
+                    [
+                        "已根据您的偏好挑选以下优质货源：",
+                        *rec_lines,
+                        "如需我代为联系货主或继续筛选，请告诉我。",
+                    ]
+                )
+            elif intent == IntentType.FIND_FREIGHT:
+                message = "暂未找到符合画像的货源，我会持续关注新单，有更新立即同步给您。"
+            elif intent == IntentType.UPDATE_PROFILE and profile:
+                pref = profile.preferences
+                message = (
+                    "画像已更新：偏好高价{}、近距离{}、装货及时{}。最近10票履约、取消、未成交记录已整理，可随时复盘。"
+                ).format(
+                    "✅" if pref.prefers_high_price else "❌",
+                    "✅" if pref.prefers_nearby else "❌",
+                    "✅" if pref.prefers_fast_turnaround else "❌",
+                )
+            elif intent == IntentType.KNOWLEDGE_QUERY and knowledge:
+                message = f"针对您的问题，我查到的规则是：{knowledge} 如果需要进一步解释或案例，请继续提问。"
+            elif intent == IntentType.KNOWLEDGE_QUERY:
+                message = "暂未检索到相关规则，我会继续搜索，也欢迎提供更多上下文。"
+            else:
+                message = "我还不确定您的需求，麻烦说明是要找货、查看画像还是咨询规则。"
+
+            memory.add_turn("assistant", message, timestamp=datetime.utcnow())
+            response = AgentResponse(
+                intent=intent,
+                message=message,
+                recommended_orders=recommendations,
+                driver_profile=profile,
+                plan=state.get("plan", []),
+            )
+            state["memory"] = memory
+            state["response"] = response
+            return state
+
+        graph.add_node("plan", plan_node)
+        graph.add_node("act", act_node)
+        graph.add_node("react", react_node)
+        graph.add_node("respond", respond_node)
+
+        graph.set_entry_point("plan")
+        graph.add_edge("plan", "act")
+        graph.add_edge("act", "react")
+        graph.add_conditional_edges("react", should_continue, {"continue": "act", "respond": "respond"})
+        graph.add_edge("respond", END)
+
+        return graph
+
+    def _memory_for_driver(self, driver_id: str) -> ConversationMemory:
+        if driver_id not in self._memory_store:
+            self._memory_store[driver_id] = ConversationMemory(self.config.max_history_turns)
+        return self._memory_store[driver_id]
+
+    def run(self, trigger: TriggerContext) -> AgentResponse:
+        """Invoke the agent for the provided trigger context."""
+
+        memory = self._memory_for_driver(trigger.driver_id)
+        state: AgentState = {"trigger": trigger, "memory": memory}
+        output = self._graph.invoke(state)
+        updated_memory = output.get("memory", memory)
+        self._memory_store[trigger.driver_id] = updated_memory
+        return output["response"]

--- a/agent_app/config.py
+++ b/agent_app/config.py
@@ -1,0 +1,36 @@
+"""Application configuration models."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import List
+
+from pydantic import BaseModel, Field
+
+
+class KnowledgeBaseConfig(BaseModel):
+    """Configuration for knowledge base retrieval."""
+
+    namespaces: List[str] = Field(
+        default_factory=lambda: ["freight_policies", "pricing_rules", "safety_guidelines"],
+        description="Ordered namespaces to search when answering driver questions.",
+    )
+    top_k: int = Field(default=4, ge=1, le=10, description="Number of documents to retrieve per query.")
+
+
+class AgentConfig(BaseModel):
+    """Configuration for the driver assistant agent."""
+
+    knowledge_base: KnowledgeBaseConfig = Field(default_factory=KnowledgeBaseConfig)
+    max_history_turns: int = Field(
+        default=12,
+        ge=1,
+        description="How many interaction turns to keep when compressing conversation context.",
+    )
+
+
+@lru_cache(maxsize=1)
+def get_agent_config() -> AgentConfig:
+    """Return the cached agent configuration."""
+
+    return AgentConfig()

--- a/agent_app/main.py
+++ b/agent_app/main.py
@@ -1,0 +1,35 @@
+"""FastAPI service exposing the driver assistant agent."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+from .agent import DriverAssistantAgent
+from .config import AgentConfig, get_agent_config
+from .models import AgentResponse, TriggerContext
+
+
+def create_app(config: AgentConfig | None = None) -> FastAPI:
+    app = FastAPI(title="Driver Assistant Agent", version="0.1.0")
+    agent_config = config or get_agent_config()
+    agent = DriverAssistantAgent(config=agent_config)
+
+    @app.post("/agent/v1/trigger", response_model=AgentResponse)
+    async def trigger_agent(
+        payload: TriggerContext,
+    ) -> JSONResponse:
+        response = agent.run(payload)
+        return JSONResponse(status_code=200, content=response.model_dump())
+
+    @app.get("/agent/v1/ping")
+    async def ping() -> Dict[str, Any]:
+        return {"status": "ok", "timestamp": datetime.utcnow().isoformat()}
+
+    return app
+
+
+app = create_app()

--- a/agent_app/memory.py
+++ b/agent_app/memory.py
@@ -1,0 +1,55 @@
+"""Conversation memory utilities for the driver assistant agent."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Deque, Iterable, List, Literal, Optional
+
+
+@dataclass
+class ConversationTurn:
+    """Single turn within the driver conversation."""
+
+    role: Literal["user", "assistant"]
+    content: str
+    timestamp: datetime
+
+
+class ConversationMemory:
+    """Ring-buffer conversation memory keeping the latest interaction turns."""
+
+    def __init__(self, max_turns: int = 12) -> None:
+        self.max_turns = max_turns
+        self._turns: Deque[ConversationTurn] = deque(maxlen=max_turns)
+
+    def add_turn(
+        self,
+        role: Literal["user", "assistant"],
+        content: str,
+        *,
+        timestamp: Optional[datetime] = None,
+    ) -> None:
+        """Append a new turn to the memory, trimming old entries if necessary."""
+
+        self._turns.append(
+            ConversationTurn(
+                role=role,
+                content=content,
+                timestamp=timestamp or datetime.utcnow(),
+            )
+        )
+
+    def history(self) -> List[ConversationTurn]:
+        """Return the stored turns as a list in chronological order."""
+
+        return list(self._turns)
+
+    def __iter__(self) -> Iterable[ConversationTurn]:
+        return iter(self._turns)
+
+    def summary(self) -> str:
+        """Generate a compact textual summary of the stored turns."""
+
+        return " | ".join(f"{turn.role}: {turn.content}" for turn in self._turns)

--- a/agent_app/models.py
+++ b/agent_app/models.py
@@ -1,0 +1,113 @@
+"""Domain models for driver assistant agent."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class FreightStatus(str, Enum):
+    """Status of a freight order."""
+
+    WON = "won"
+    LOST = "lost"
+    CANCELLED = "cancelled"
+    IN_PROGRESS = "in_progress"
+
+
+class VoiceSummary(BaseModel):
+    """Summary of a voice conversation."""
+
+    transcript: str = Field(description="Transcribed content of the call or voice note.")
+    duration_seconds: int = Field(ge=0, description="Duration of the recording in seconds.")
+
+
+class FreightOrder(BaseModel):
+    """Freight order record."""
+
+    order_id: str
+    origin: str
+    destination: str
+    price: float
+    pickup_time: datetime
+    status: FreightStatus
+    voice: Optional[VoiceSummary] = None
+
+
+class DriverPreference(BaseModel):
+    """Driver preference profile extracted from history."""
+
+    prefers_high_price: bool = Field(default=False, description="Driver prioritises high paying shipments.")
+    prefers_nearby: bool = Field(default=False, description="Driver prioritises nearby shipments to reduce deadhead miles.")
+    prefers_fast_turnaround: bool = Field(default=False, description="Driver prefers shipments starting soon.")
+    notes: str = Field(default="", description="Additional qualitative preference notes.")
+
+
+class DriverProfile(BaseModel):
+    """Aggregated driver profile with freight history."""
+
+    driver_id: str
+    score: float = Field(default=0.0, ge=0.0, le=1.0)
+    recent_wins: List[FreightOrder] = Field(default_factory=list)
+    recent_cancellations: List[FreightOrder] = Field(default_factory=list)
+    recent_missed: List[FreightOrder] = Field(default_factory=list)
+    preferences: DriverPreference = Field(default_factory=DriverPreference)
+
+
+class FreightOpportunity(BaseModel):
+    """Candidate freight opportunity for matching."""
+
+    order_id: str
+    origin: str
+    destination: str
+    price: float
+    distance_km: float
+    pickup_time: datetime
+    cargo_type: str
+    weight_tons: float
+
+
+class IntentType(str, Enum):
+    """Enumerated intents recognised by the agent."""
+
+    FIND_FREIGHT = "find_freight"
+    UPDATE_PROFILE = "update_profile"
+    KNOWLEDGE_QUERY = "knowledge_query"
+    UNKNOWN = "unknown"
+
+
+class PlanStepType(str, Enum):
+    """Kinds of planning steps the agent can execute."""
+
+    TOOL = "tool"
+    REASON = "reason"
+
+
+class PlanStep(BaseModel):
+    """Single step within the agent planner output."""
+
+    step_type: PlanStepType = Field(description="Whether this step uses a tool or is internal reasoning.")
+    name: str = Field(description="Identifier for the step, typically matching a tool or reasoning label.")
+    description: str = Field(description="Natural language explanation of what the step is accomplishing.")
+
+
+class TriggerContext(BaseModel):
+    """Trigger context passed to the agent when invoked."""
+
+    driver_id: str
+    channel: str
+    utterance: str
+    timestamp: datetime
+
+
+class AgentResponse(BaseModel):
+    """Response returned to the client after processing."""
+
+    intent: IntentType
+    message: str
+    recommended_orders: List[FreightOpportunity] = Field(default_factory=list)
+    driver_profile: Optional[DriverProfile] = None
+    plan: List[PlanStep] = Field(default_factory=list, description="Planner steps executed for this response.")

--- a/agent_app/planner.py
+++ b/agent_app/planner.py
@@ -1,0 +1,81 @@
+"""Deterministic planner assembling tool execution plans for the driver assistant agent."""
+
+from __future__ import annotations
+
+from typing import List
+
+from .memory import ConversationMemory
+from .models import IntentType, PlanStep, PlanStepType, TriggerContext
+
+
+class RuleBasedPlanner:
+    """Simple rule-based planner mapping intents to tool sequences."""
+
+    def make_plan(
+        self,
+        intent: IntentType,
+        trigger: TriggerContext,
+        memory: ConversationMemory,
+    ) -> List[PlanStep]:
+        """Create an ordered list of plan steps for the current trigger."""
+
+        if intent == IntentType.FIND_FREIGHT:
+            return [
+                PlanStep(
+                    step_type=PlanStepType.TOOL,
+                    name="fetch_profile",
+                    description="刷新司机画像，获取最近履约、取消、未成交记录与偏好。",
+                ),
+                PlanStep(
+                    step_type=PlanStepType.REASON,
+                    name="align_preferences",
+                    description="结合历史对话与画像偏好，判断当前找货需求的重点。",
+                ),
+                PlanStep(
+                    step_type=PlanStepType.TOOL,
+                    name="recommend_freight",
+                    description="匹配符合偏好的即时货源，并准备推荐话术。",
+                ),
+            ]
+
+        if intent == IntentType.UPDATE_PROFILE:
+            return [
+                PlanStep(
+                    step_type=PlanStepType.TOOL,
+                    name="fetch_profile",
+                    description="同步司机画像详情并提炼可用亮点。",
+                ),
+                PlanStep(
+                    step_type=PlanStepType.REASON,
+                    name="profile_summary",
+                    description="结合最近对话，为司机总结画像重点和建议。",
+                ),
+            ]
+
+        if intent == IntentType.KNOWLEDGE_QUERY:
+            return [
+                PlanStep(
+                    step_type=PlanStepType.REASON,
+                    name="clarify_question",
+                    description="理解司机问题的意图，确定需要查询的规则方向。",
+                ),
+                PlanStep(
+                    step_type=PlanStepType.TOOL,
+                    name="query_knowledge",
+                    description="查询行业知识库或平台规则，返回具体指引。",
+                ),
+                PlanStep(
+                    step_type=PlanStepType.REASON,
+                    name="ground_answer",
+                    description="结合司机画像及场景，给出可执行建议。",
+                ),
+            ]
+
+        # Default fall-back prompts the agent to clarify the intent.
+        return [
+            PlanStep(
+                step_type=PlanStepType.REASON,
+                name="clarify_intent",
+                description="当前无法识别司机需求，需要向司机澄清目标。",
+            )
+        ]

--- a/agent_app/tools.py
+++ b/agent_app/tools.py
@@ -128,7 +128,15 @@ class IntentRouterTool:
 
     def infer_intent(self, utterance: str) -> IntentType:
         utterance = utterance.lower()
-        if "找货" in utterance or "货" in utterance:
+        normalized = utterance.replace(" ", "")
+        freight_keywords = [
+            "找货",
+            "配货",
+            "货源",
+            "推荐货",
+            "有货吗",
+        ]
+        if any(keyword in normalized for keyword in freight_keywords):
             return IntentType.FIND_FREIGHT
         if "资料" in utterance or "画像" in utterance:
             return IntentType.UPDATE_PROFILE

--- a/agent_app/tools.py
+++ b/agent_app/tools.py
@@ -1,0 +1,171 @@
+"""Mock business tools for the driver assistant agent."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import List
+
+from .models import (
+    AgentResponse,
+    DriverPreference,
+    DriverProfile,
+    FreightOpportunity,
+    FreightOrder,
+    FreightStatus,
+    IntentType,
+    TriggerContext,
+    VoiceSummary,
+)
+
+
+class DriverProfileTool:
+    """Fetch driver profiles and behavioural preferences."""
+
+    def fetch_profile(self, driver_id: str) -> DriverProfile:
+        now = datetime.utcnow()
+        voice = VoiceSummary(transcript="货主希望下午四点前装车", duration_seconds=78)
+        base_order = dict(origin="上海", destination="杭州", price=5200.0, pickup_time=now - timedelta(days=2))
+        wins = [
+            FreightOrder(
+                order_id=f"WIN-{i}",
+                status=FreightStatus.WON,
+                voice=voice,
+                **base_order,
+            )
+            for i in range(1, 11)
+        ]
+        cancellations = [
+            FreightOrder(
+                order_id=f"CANCEL-{i}",
+                status=FreightStatus.CANCELLED,
+                pickup_time=now - timedelta(days=3 + i),
+                origin="上海",
+                destination="苏州",
+                price=4100.0,
+                voice=voice,
+            )
+            for i in range(1, 6)
+        ]
+        missed = [
+            FreightOrder(
+                order_id=f"MISSED-{i}",
+                status=FreightStatus.LOST,
+                pickup_time=now - timedelta(days=1 + i),
+                origin="上海",
+                destination="南京",
+                price=6200.0,
+                voice=voice,
+            )
+            for i in range(1, 6)
+        ]
+        preferences = DriverPreference(
+            prefers_high_price=True,
+            prefers_nearby=True,
+            prefers_fast_turnaround=True,
+            notes="司机偏好高价、近距离且装货时间更近的货源。",
+        )
+        return DriverProfile(
+            driver_id=driver_id,
+            score=0.86,
+            recent_wins=wins,
+            recent_cancellations=cancellations,
+            recent_missed=missed,
+            preferences=preferences,
+        )
+
+
+class FreightCatalogTool:
+    """Mock tool providing freight opportunities."""
+
+    def recommend(self, driver_profile: DriverProfile, limit: int = 5) -> List[FreightOpportunity]:
+        base_pickup = datetime.utcnow() + timedelta(hours=2)
+        opportunities = [
+            FreightOpportunity(
+                order_id="NEW-001",
+                origin="上海",
+                destination="杭州",
+                price=6600.0,
+                distance_km=180.0,
+                pickup_time=base_pickup,
+                cargo_type="电子产品",
+                weight_tons=10.0,
+            ),
+            FreightOpportunity(
+                order_id="NEW-002",
+                origin="上海",
+                destination="嘉兴",
+                price=5200.0,
+                distance_km=95.0,
+                pickup_time=base_pickup + timedelta(hours=1),
+                cargo_type="日用品",
+                weight_tons=8.0,
+            ),
+            FreightOpportunity(
+                order_id="NEW-003",
+                origin="上海",
+                destination="苏州",
+                price=4800.0,
+                distance_km=100.0,
+                pickup_time=base_pickup + timedelta(hours=3),
+                cargo_type="冷链食品",
+                weight_tons=12.0,
+            ),
+        ]
+        # Filter according to preferences
+        filtered = [opp for opp in opportunities if opp.price >= 5000 or driver_profile.preferences.prefers_nearby]
+        return filtered[:limit]
+
+
+class KnowledgeBaseTool:
+    """Mock tool simulating knowledge base lookup."""
+
+    def query(self, question: str) -> str:
+        return "根据平台规则，装货前需提前30分钟到场并完成安全检查。"
+
+
+class IntentRouterTool:
+    """Simple intent classifier."""
+
+    def infer_intent(self, utterance: str) -> IntentType:
+        utterance = utterance.lower()
+        if "找货" in utterance or "货" in utterance:
+            return IntentType.FIND_FREIGHT
+        if "资料" in utterance or "画像" in utterance:
+            return IntentType.UPDATE_PROFILE
+        if "规则" in utterance or "怎么" in utterance:
+            return IntentType.KNOWLEDGE_QUERY
+        return IntentType.UNKNOWN
+
+
+class DriverAssistantToolkit:
+    """Aggregate toolkit used by the driver assistant agent."""
+
+    def __init__(self) -> None:
+        self.driver_profile = DriverProfileTool()
+        self.freight_catalog = FreightCatalogTool()
+        self.knowledge_base = KnowledgeBaseTool()
+        self.intent_router = IntentRouterTool()
+
+    def handle(self, trigger: TriggerContext) -> AgentResponse:
+        intent = self.intent_router.infer_intent(trigger.utterance)
+        profile = self.driver_profile.fetch_profile(trigger.driver_id)
+
+        if intent == IntentType.FIND_FREIGHT:
+            recommendations = self.freight_catalog.recommend(profile)
+            message = "已为您挑选符合偏好的最新货源，是否需要立即联系货主？"
+            return AgentResponse(
+                intent=intent,
+                message=message,
+                recommended_orders=recommendations,
+                driver_profile=profile,
+            )
+        if intent == IntentType.UPDATE_PROFILE:
+            message = "已同步司机画像，包括最近履约、取消、未成交记录及偏好标签。"
+            return AgentResponse(intent=intent, message=message, driver_profile=profile)
+        if intent == IntentType.KNOWLEDGE_QUERY:
+            answer = self.knowledge_base.query(trigger.utterance)
+            message = f"为您找到的规则：{answer}"
+            return AgentResponse(intent=intent, message=message, driver_profile=profile)
+
+        message = "我没有理解您的需求，请问是要找货、更新画像还是咨询平台规则？"
+        return AgentResponse(intent=intent, message=message, driver_profile=profile)

--- a/docs/driver_assistant_architecture.md
+++ b/docs/driver_assistant_architecture.md
@@ -1,0 +1,75 @@
+# Driver Assistant Agent Architecture & Team Organization
+
+## 1. Context & Objectives
+- **Business goal**: empower platform drivers to earn more with less effort by automating planning, execution support, and issue resolution throughout the delivery lifecycle.
+- **Product north star**: "One-tap co-pilot" that integrates seamlessly with existing driver app, surfaces timely guidance, and coordinates follow-up actions across the logistics ecosystem.
+- **Team reality**: 7-8 AI engineers covering agent, ML, backend, and ops responsibilities. Need clear ownership aligned with agent lifecycle to avoid fragmented delivery.
+
+## 2. Architectural Layers
+| Layer | Purpose | Key Capabilities | Suggested Tech Stack |
+| --- | --- | --- | --- |
+| Experience Orchestration | Manage end-to-end driver journeys, dialogue state, and KPI tracking | Scenario routing, evaluation harness, outcome attribution | LangGraph agent graphs (Planner+ReAct), FastAPI, internal logging/metrics |
+| Agent Runtime & Infra | Provide reliable execution environment for agents and sub-agents | Session management, tool registry, execution tracing, fault handling | LangGraph, uv package mgmt, OpenTelemetry, feature flags |
+| Knowledge & Context Fabric | Aggregate driver profile, intents, ops data, and industry knowledge | Context synthesis, retrieval-augmented prompting, knowledge governance | Vector DB, feature store, cached profiles, domain KB connectors |
+| Tooling Layer | Encapsulate platform & external actions via mockable tool interfaces | Order ops APIs, navigation, pricing, compliance checks, support workflows | FastAPI wrappers, typed clients, synthetic mocks, contract tests |
+| Feedback & Evaluation Loop | Measure agent quality, collect driver feedback, and trigger improvements | Scenario definitions, eval suites, offline/online metrics, human review | Eval harness (LangSmith, custom), dashboards, annotation tools |
+
+## 3. Agent System Design
+1. **Agent Control Loop（Planner + Memory + ReAct）**
+   - Planner：根据触发意图生成工具/推理步骤序列（例如刷新画像 → 偏好对齐 → 匹配货源），并向外暴露可追溯的计划列表。
+   - ReAct Executor：逐步执行计划，调用工具获取画像、货源或知识库反馈，并将观察写入 scratchpad。
+   - 记忆：使用环形缓存维护最近多轮对话，支撑 Planner 调整策略并输出可追溯的计划。
+2. **Multi-Agent Topology**
+   - *Coordinator Agent*: supervises conversations, delegates to specialists, applies escalation policies.
+   - *Specialist Agents*: execution planning, compliance advisor, earnings optimizer, support concierge. Each exposes a narrow tool set for the coordinator.
+   - *Knowledge Agents*: handle driver profile enrichment and knowledge retrieval; provide structured context objects instead of direct conversation.
+3. **Dialogue & Memory Strategy**
+   - Conversation graph with checkpoints (pre-trip, en-route, post-delivery).
+   - Rolling short-term memory (recent turns) plus episodic summaries via compress-and-cache strategy.
+   - Prompt templates referencing driver persona, current job, environment signals.
+4. **Tool Management**
+   - Contract-first definitions; ability to mock tools for offline testing.
+   - Tool health monitoring (latency, error rate) with automatic fallback to scripted flows.
+
+## 4. Triggering & Intent Flow
+1. **Trigger Sources**: driver app events, telematics, order lifecycle events, manual pings.
+2. **Intent Detection**: lightweight classifier + heuristics. Support intent upsert and feedback loop.
+3. **Context Assembly**: fetch driver baseline profile, current tasks, historical incidents, weather/traffic signals, and scenario-specific knowledge cards.
+4. **Action Selection**: orchestrator picks best sub-agent/tools; ensures SLA guardrails.
+
+## 5. Team Structure & Ownership
+| Pod | Headcount | Primary Scope | Deliverables |
+| --- | --- | --- | --- |
+| Agent Orchestration Pod | 2 | Conversation graph, coordinator agent, evaluation harness | LangGraph flows, policy configs, scenario scorecards |
+| Infra & Reliability Pod | 2 | Runtime stability, observability, fault recovery, deployment | Tool registry, tracing dashboards, chaos testing playbook |
+| Knowledge & Profile Pod | 2 | Driver persona modeling, knowledge ingestion, context APIs | Profile service, retrieval pipelines, quality benchmarks |
+| Tooling & Integration Pod | 1-2 | Platform API wrappers, mock tools, trigger ingestion | Tool SDK, mock harness, contract tests |
+| Feedback & Insights Pod (part-time) | 1 | Evaluation data analysis, driver feedback loop | Eval reports, annotation guidelines, prioritization backlog |
+
+> **Responsibility Model**: Each pod owns both build & run of its scope; coordinator role (tech lead) ensures cross-pod alignment and reviews.
+
+## 6. Delivery Cadence & Interfaces
+- **Quarterly**: roadmap alignment, scenario expansion targets, shared OKRs (activation, retention, NPS, automation rate).
+- **Biweekly**: agent-level demos & eval reviews; cross-pod dependency sync.
+- **Weekly**: pod standups, runbook updates, incident reviews.
+- **Artifacts**: API contracts, prompt specs, tool schemas, scenario scorecards, eval dashboards.
+
+## 7. Sub-Agent Definition Guidance
+- Define sub-agents around **driver-facing capabilities** (e.g., earnings optimization), not data assets.
+- Each sub-agent must own: prompt templates, tools, evaluation cases, fallback flows.
+- Supporting pods (e.g., profile) deliver consumable **context services** to sub-agents, but do not operate as agents.
+- Use RFC checklist before adding new sub-agent: business KPI impact, tool availability, observability plan, evaluation coverage.
+
+## 8. Execution Guardrails
+- **Observability**: standard tracing + conversation analytics; automated alerts on failure spikes.
+- **Stability**: degraded-mode prompts, circuit breakers for flaky tools, synthetic fallback responses.
+- **Compliance & Safety**: scenario-specific guardrails (no unsafe driving advice), human handoff policy.
+- **Knowledge Governance**: freshness SLAs, versioned KB releases, audit logs for critical guidance.
+
+## 9. Next Steps (0-1 Plan)
+1. Align on top 3 driver scenarios (e.g., load acceptance, en-route issue resolution, post-trip earnings insights).
+2. Build MVP coordinator with mock tools and scripted evaluation harness.
+3. Stand up observability baseline (tracing, logging) + failure triage workflow.
+4. Deliver first persona & context APIs; integrate into prompt assembly.
+5. Run scenario pilots with closed beta drivers; collect feedback -> iterate.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "driver-assistant-agent"
+version = "0.1.0"
+description = "Driver assistant agent service built with LangGraph and FastAPI"
+authors = [{name = "Logistics AI Team"}]
+requires-python = ">=3.10"
+dependencies = [
+    "fastapi>=0.110",
+    "langgraph>=0.2",
+    "langchain-core>=0.1",
+    "pydantic>=2.6",
+    "uvicorn>=0.27",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "httpx>=0.27"
+]
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- replace the previous LangGraph workflow with a planner-driven agent that maintains memory and executes ReAct loops via the new DriverAssistantAgent
- add conversation memory and rule-based planner modules so responses expose the executed plan and richer reasoning traces
- update the FastAPI entrypoint, README, and architecture documentation to reflect the planner + memory oriented design

## Testing
- not run (langgraph dependency is not installed in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68eb8980c298832596492332784d0425